### PR TITLE
CO-3389 Giving read access to portal user for crowdfunding donation

### DIFF
--- a/base_location/security/ir.model.access.csv
+++ b/base_location/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
-"ir_model_access_cityzip0","res_city_zip group_user","model_res_city_zip","base.group_partner_manager",1,1,1,1
+"ir_model_access_cityzip0","res_city_zip group_partner_manager","model_res_city_zip","base.group_partner_manager",1,1,1,1
+"ir_model_access_cityzip1","res_city_zip group_portal","model_res_city_zip","base.group_portal",1,0,0,0


### PR DESCRIPTION
Because of this missing access right, some users were not able to reach the payment page on the crowdfunding website. I also renamed the other access rule to a more explicit one.